### PR TITLE
Add category update/delete endpoints

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -33,6 +33,21 @@ def get_or_create_category(db: Session, name: str):
     db.refresh(category)
     return category
 
+
+def update_category(db: Session, category: models.Category, data: schemas.CategoryBase) -> models.Category:
+    """Update a category with the provided data."""
+    for field, value in data.dict().items():
+        setattr(category, field, value)
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+def delete_category(db: Session, category: models.Category) -> None:
+    """Delete a category object."""
+    db.delete(category)
+    db.commit()
+
 # Product CRUD
 def create_product(db: Session, product: schemas.ProductCreate):
     db_product = models.Product(**product.dict())

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from .. import schemas, crud, models
@@ -16,3 +16,20 @@ def create_category(category: schemas.CategoryBase, db: Session = Depends(get_db
 @router.get("/", response_model=list[schemas.Category])
 def list_categories(db: Session = Depends(get_db)):
     return db.query(models.Category).all()
+
+
+@router.put("/{category_id}", response_model=schemas.Category, dependencies=[Depends(admin_required)])
+def update_category(category_id: int, data: schemas.CategoryBase, db: Session = Depends(get_db)):
+    category = db.query(models.Category).filter(models.Category.id == category_id).first()
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return crud.update_category(db, category, data)
+
+
+@router.delete("/{category_id}", status_code=204, dependencies=[Depends(admin_required)])
+def delete_category(category_id: int, db: Session = Depends(get_db)):
+    category = db.query(models.Category).filter(models.Category.id == category_id).first()
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    crud.delete_category(db, category)
+    return None


### PR DESCRIPTION
## Summary
- implement CRUD helpers for categories
- add update and delete routes for /categories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6869693f8cec8333a877dd56d7b9b458