### PR TITLE
Add cart update/delete endpoints

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -158,6 +158,21 @@ def create_notification(db: Session, user_id: int, message: str):
     return notif
 
 
+# ---- Cart helpers ----
+def update_cart_item_quantity(
+    db: Session, item: models.CartItem, quantity: int
+) -> models.CartItem:
+    item.quantity = quantity
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+def delete_cart_item(db: Session, item: models.CartItem) -> None:
+    db.delete(item)
+    db.commit()
+
+
 # ---- Wishlist helpers ----
 def add_to_wishlist(db: Session, user_id: int, product_id: int) -> models.WishlistItem:
     item = (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,6 +119,26 @@ def test_full_flow(tokens):
     assert resp.status_code == 200
     assert resp.json()["serviceable"] is True
 
+    # cart item operations
+    resp = client.post(
+        "/cart/",
+        json={"product_id": product_id, "quantity": 2},
+        headers={"Authorization": tokens["user"]},
+    )
+    assert resp.status_code == 200
+    item_id = resp.json()["id"]
+
+    resp = client.put(
+        f"/cart/{item_id}",
+        json=3,
+        headers={"Authorization": tokens["user"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["quantity"] == 3
+
+    resp = client.delete(f"/cart/{item_id}", headers={"Authorization": tokens["user"]})
+    assert resp.status_code == 200
+
     # user places an order
     resp = client.post(
         "/cart/",


### PR DESCRIPTION
## Summary
- add cart CRUD helpers
- add endpoints to update cart item quantity and delete items
- test cart update and delete functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686969d919a88333b36e1f6b711c3ea0