### PR TITLE
Add order retrieval endpoint

### DIFF
--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -50,3 +50,17 @@ def list_orders(
 @router.get("/all", response_model=list[schemas.Order], dependencies=[Depends(dependencies.admin_required)])
 def list_all_orders(db: Session = Depends(dependencies.get_db)):
     return db.query(models.Order).all()
+
+
+@router.get("/{order_id}", response_model=schemas.Order)
+def get_order(
+    order_id: int,
+    db: Session = Depends(dependencies.get_db),
+    current_user: models.User = Depends(auth_utils.get_current_user),
+):
+    order = db.query(models.Order).filter(models.Order.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    if order.user_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    return order

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -150,6 +150,15 @@ def test_full_flow(tokens):
     assert resp.status_code == 200
     order_id = resp.json()["id"]
 
+    # fetch the order as the user
+    resp = client.get(f"/orders/{order_id}", headers={"Authorization": tokens["user"]})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == order_id
+
+    # admin can access the order
+    resp = client.get(f"/orders/{order_id}", headers={"Authorization": tokens["admin"]})
+    assert resp.status_code == 200
+
     # confirm payment
     resp = client.post(f"/payments/{order_id}")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- implement `GET /orders/{order_id}` for fetching order details
- ensure access restricted to the order's owner or admins
- extend test suite to check order retrieval behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68696b7e1b4883339ecd59e2e9d228b0