### PR TITLE
Add automatic notifications for order status

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1,0 +1,6 @@
+from typing import Optional
+
+
+def send_email(to: str, subject: str, body: str) -> None:
+    """Placeholder email sender that just prints the email contents."""
+    print(f"Sending email to {to}: {subject} - {body}")

--- a/app/routers/delivery.py
+++ b/app/routers/delivery.py
@@ -2,21 +2,33 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import datetime
 
-from .. import schemas, models, dependencies
+from .. import schemas, models, dependencies, crud
 
 router = APIRouter(prefix="/delivery", tags=["delivery"])
 
 
-@router.get("/assignable", response_model=list[schemas.Order], dependencies=[Depends(dependencies.delivery_required)])
+@router.get(
+    "/assignable",
+    response_model=list[schemas.Order],
+    dependencies=[Depends(dependencies.delivery_required)],
+)
 def list_assignable_orders(db: Session = Depends(dependencies.get_db)):
     # orders paid and not yet assigned
-    return db.query(models.Order).filter(
-        models.Order.status == models.OrderStatus.paid,
-        models.Order.delivery_assignment == None,  # noqa: E711
-    ).all()
+    return (
+        db.query(models.Order)
+        .filter(
+            models.Order.status == models.OrderStatus.paid,
+            models.Order.delivery_assignment == None,  # noqa: E711
+        )
+        .all()
+    )
 
 
-@router.post("/assign/{order_id}", response_model=schemas.DeliveryAssignment, dependencies=[Depends(dependencies.delivery_required)])
+@router.post(
+    "/assign/{order_id}",
+    response_model=schemas.DeliveryAssignment,
+    dependencies=[Depends(dependencies.delivery_required)],
+)
 def take_order(
     order_id: int,
     current_user: models.User = Depends(dependencies.delivery_required),
@@ -27,29 +39,37 @@ def take_order(
         raise HTTPException(status_code=400, detail="Order not assignable")
     if order.delivery_assignment:
         raise HTTPException(status_code=400, detail="Already assigned")
-    assignment = models.DeliveryAssignment(order_id=order.id, delivery_partner_id=current_user.id)
-    order.status = models.OrderStatus.out_for_delivery
+    assignment = models.DeliveryAssignment(
+        order_id=order.id, delivery_partner_id=current_user.id
+    )
     db.add(assignment)
-    db.commit()
+    crud.update_order_status(db, order, models.OrderStatus.out_for_delivery)
     db.refresh(assignment)
     return assignment
 
 
-@router.post("/delivered/{order_id}", response_model=schemas.Order, dependencies=[Depends(dependencies.delivery_required)])
+@router.post(
+    "/delivered/{order_id}",
+    response_model=schemas.Order,
+    dependencies=[Depends(dependencies.delivery_required)],
+)
 def mark_delivered(
     order_id: int,
     current_user: models.User = Depends(dependencies.delivery_required),
     db: Session = Depends(dependencies.get_db),
 ):
-    assignment = db.query(models.DeliveryAssignment).filter(
-        models.DeliveryAssignment.order_id == order_id,
-        models.DeliveryAssignment.delivery_partner_id == current_user.id,
-    ).first()
+    assignment = (
+        db.query(models.DeliveryAssignment)
+        .filter(
+            models.DeliveryAssignment.order_id == order_id,
+            models.DeliveryAssignment.delivery_partner_id == current_user.id,
+        )
+        .first()
+    )
     if not assignment:
         raise HTTPException(status_code=404, detail="Assignment not found")
     assignment.delivered_at = datetime.datetime.utcnow()
     order = assignment.order
-    order.status = models.OrderStatus.delivered
-    db.commit()
+    crud.update_order_status(db, order, models.OrderStatus.delivered)
     db.refresh(order)
     return order

--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from .. import schemas, crud, auth, models
@@ -6,6 +6,33 @@ from ..dependencies import get_db
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
+
 @router.get("/", response_model=list[schemas.Notification])
-def get_notifications(db: Session = Depends(get_db), current_user: models.User = Depends(auth.get_current_user)):
-    return db.query(models.Notification).filter(models.Notification.user_id == current_user.id).all()
+def get_notifications(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    return (
+        db.query(models.Notification)
+        .filter(models.Notification.user_id == current_user.id)
+        .all()
+    )
+
+
+@router.patch("/{notification_id}/read", response_model=schemas.Notification)
+def mark_read(
+    notification_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    notif = (
+        db.query(models.Notification)
+        .filter(
+            models.Notification.id == notification_id,
+            models.Notification.user_id == current_user.id,
+        )
+        .first()
+    )
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return crud.mark_notification_read(db, notif)

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -27,6 +27,7 @@ def initiate_payment(order_id: int, db: Session = Depends(dependencies.get_db)):
     db.refresh(payment)
     return payment
 
+
 # Simple mock payment confirmation
 @router.post("/{order_id}", response_model=schemas.Payment)
 def confirm_payment(order_id: int, db: Session = Depends(dependencies.get_db)):
@@ -34,7 +35,9 @@ def confirm_payment(order_id: int, db: Session = Depends(dependencies.get_db)):
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
     if order.status != models.OrderStatus.pending:
-        raise HTTPException(status_code=400, detail="Payment already processed or order invalid")
+        raise HTTPException(
+            status_code=400, detail="Payment already processed or order invalid"
+        )
 
     payment = models.Payment(
         order_id=order.id,
@@ -43,10 +46,7 @@ def confirm_payment(order_id: int, db: Session = Depends(dependencies.get_db)):
         status=models.PaymentStatus.confirmed,
     )
     db.add(payment)
-    # Update order status
-    order.status = models.OrderStatus.paid
-    db.commit()
+    crud.update_order_status(db, order, models.OrderStatus.paid)
     db.refresh(payment)
     db.refresh(order)
     return payment
-

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,14 +198,18 @@ def test_full_flow(tokens):
     )
     assert resp.status_code == 200
 
-    # 14. Create notification and fetch it
-    db = database.SessionLocal()
-    create_notification(db, tokens["user_id"], "Order preparing")
-    db.close()
-
+    # 14. Notification auto-created and mark as read
     resp = client.get("/notifications/", headers={"Authorization": tokens["user"]})
     assert resp.status_code == 200
     assert len(resp.json()) == 1
+    notif_id = resp.json()[0]["id"]
+
+    resp = client.patch(
+        f"/notifications/{notif_id}/read",
+        headers={"Authorization": tokens["user"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["read"] is True
 
     # 15. Admin analytics endpoint
     resp = client.get("/admin/stats", headers={"Authorization": tokens["admin"]})


### PR DESCRIPTION
## Summary
- send email and SMS notifications when an order status changes
- mark notifications as read via new PATCH endpoint
- ensure delivery and payment flows trigger `update_order_status`
- extend API test for new notification behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686976f3f090833383ce4886453202d6