### PR TITLE
Add estimated delivery field

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -101,6 +101,7 @@ class Order(Base):
     total = Column(Float, default=0.0)
     coupon_id = Column(Integer, ForeignKey("coupons.id"), nullable=True)
     status = Column(Enum(OrderStatus), default=OrderStatus.pending)
+    estimated_delivery = Column(DateTime, nullable=True)
 
     user = relationship("User", back_populates="orders")
     items = relationship("OrderItem", back_populates="order")

--- a/app/routers/delivery.py
+++ b/app/routers/delivery.py
@@ -42,6 +42,8 @@ def take_order(
     assignment = models.DeliveryAssignment(
         order_id=order.id, delivery_partner_id=current_user.id
     )
+    # Compute and set estimated delivery time (ETA)
+    order.estimated_delivery = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
     db.add(assignment)
     crud.update_order_status(db, order, models.OrderStatus.out_for_delivery)
     db.refresh(assignment)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -150,6 +150,7 @@ class Order(BaseModel):
     total: float
     coupon_id: Optional[int] = None
     status: OrderStatus
+    estimated_delivery: Optional[datetime.datetime] = None
     items: List[OrderItem]
 
     class Config:


### PR DESCRIPTION
## Summary
- add `estimated_delivery` to Order model
- expose `estimated_delivery` in Order schema
- set ETA when a delivery partner accepts an order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686979fc414883338b1c6672cd5b0bd6