### PR TITLE
Add recommendations endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from .routers import (          # noqa: E402
     wishlist,
     checkout,
     admin_analytics,
+    recommendations as recommendations_router,
     misc,
 )
 
@@ -55,4 +56,5 @@ app.include_router(wallet.router)
 app.include_router(wishlist.router)
 app.include_router(checkout.router)
 app.include_router(admin_analytics.router)
+app.include_router(recommendations_router.router)
 app.include_router(misc.router)

--- a/app/recommendations.py
+++ b/app/recommendations.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from . import models
+
+
+def top_products(db: Session, limit: int = 5) -> list[models.Product]:
+    """Return products with highest order quantities overall."""
+    return (
+        db.query(models.Product)
+        .join(models.OrderItem)
+        .group_by(models.Product.id)
+        .order_by(func.sum(models.OrderItem.quantity).desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def user_purchase_history(db: Session, user_id: int, limit: int = 5) -> list[models.Product]:
+    """Return products previously purchased by the user."""
+    return (
+        db.query(models.Product)
+        .join(models.OrderItem)
+        .join(models.Order)
+        .filter(models.Order.user_id == user_id)
+        .group_by(models.Product.id)
+        .order_by(func.sum(models.OrderItem.quantity).desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def get_recommendations(db: Session, user_id: int, limit: int = 5) -> list[models.Product]:
+    """Simple recommendation combining user history and top products."""
+    history = user_purchase_history(db, user_id, limit)
+    if history:
+        return history
+    return top_products(db, limit)

--- a/app/routers/recommendations.py
+++ b/app/routers/recommendations.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from .. import models, auth, dependencies, recommendations
+
+router = APIRouter(prefix="/recommendations", tags=["recommendations"])
+
+
+@router.get("/", response_model=list[models.Product])
+def get_recommendations(
+    db: Session = Depends(dependencies.get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+    limit: int = 5,
+):
+    return recommendations.get_recommendations(db, current_user.id, limit)


### PR DESCRIPTION
## Summary
- add recommendation module with simplistic logic
- add router for /recommendations requiring auth
- wire new router in app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68697aa99e2883339696cfe5bde32ca3