### PR TITLE
Add CORS middleware to FastAPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .database import Base, engine
 
 # 1️⃣  create FastAPI app first
@@ -6,6 +7,14 @@ app = FastAPI(
     title="GreenBasket API (Advanced)",
     description="BigBasket-level backend with admin, delivery, payments",
     version="2.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://sampledev-eng.github.io"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # 2️⃣  create DB tables


### PR DESCRIPTION
## Summary
- enable cross-origin requests for the frontend domain

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68698972dd6883339ad7b24cc04aaba4